### PR TITLE
Fix unresponsive search preview

### DIFF
--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.5;
+				MARKETING_VERSION = 0.0.6;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.7;
+				MARKETING_VERSION = 0.0.8;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.10;
+				MARKETING_VERSION = 0.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.8;
+				MARKETING_VERSION = 0.0.9;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.4;
+				MARKETING_VERSION = 0.0.5;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.3;
+				MARKETING_VERSION = 0.0.4;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.6;
+				MARKETING_VERSION = 0.0.7;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
+++ b/google-viewer/AlfredGoogleViewer.xcodeproj/project.pbxproj
@@ -320,7 +320,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 0.0.9;
+				MARKETING_VERSION = 0.0.10;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CODE_SIGN_FLAGS = "--deep";
 				PRODUCT_BUNDLE_IDENTIFIER = mr.pennyworth.AlfredGoogleViewer;

--- a/google-viewer/AlfredGoogleViewer/main.swift
+++ b/google-viewer/AlfredGoogleViewer/main.swift
@@ -92,7 +92,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   func searchGoogle(_ query: String) {
     self.webview.evaluateJavaScript(
       """
-      document.querySelector("input[name='q']").value = "\(query)";
+      document.querySelector("textarea[name='q']").value = "\(query)";
       document.querySelector('form').submit();
       """,
       completionHandler: { (out, err) in

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -44,7 +44,7 @@ if __name__ == '__main__':
 try:
   # https://stackoverflow.com/a/50466440
   urllib.parse.quote_plus = urllib.parse.quote
-  subprocess.call([
+  output = subprocess.call([
     'open', '-g',
     'alfred-google-viewer://update?%s' % urllib.parse.urlencode({
       'rawQuery': rawQuery,
@@ -52,8 +52,10 @@ try:
       'bkgColor': bkgColorWithoutAlpha
     })
   ])
-except Exception as e:
-  logger.error(e)
+except subprocess.CalledProcessError as exc:
+    print("Status : FAIL", exc.returncode, exc.output)
+else:
+    print("Output: \n{}\n".format(output))
 
 print(json.dumps(alfreditems, indent=2))
 sys.stdout.flush()

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -53,12 +53,7 @@ try:
     })
   ])
 except subprocess.CalledProcessError as exc:
-    print(json.dumps(("Status : FAIL", exc.returncode, exc.output), indent=2))
+    print("Status : FAIL", exc.returncode, exc.output)
 else:
-  json_data = {
-      "alfred_items": alfreditems,
-      "output": output,
-  }
-
-  print(json.dumps(json_data, indent=2))
+  print(json.dumps(alfreditems, indent=2))
   sys.stdout.flush()

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -41,6 +41,7 @@ if __name__ == '__main__':
   bkgColor = alfred.theme()['window.color']
   bkgColorWithoutAlpha = bkgColor[:-2]
 
+try:
   # https://stackoverflow.com/a/50466440
   urllib.parse.quote_plus = urllib.parse.quote
   subprocess.call([
@@ -51,6 +52,8 @@ if __name__ == '__main__':
       'bkgColor': bkgColorWithoutAlpha
     })
   ])
+except Exception as e:
+  logger.error(e)
 
   print(json.dumps(alfreditems, indent=2))
   sys.stdout.flush()

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -53,9 +53,9 @@ try:
     })
   ])
 except subprocess.CalledProcessError as exc:
-    print("Status : FAIL", exc.returncode, exc.output)
+    print(json.dumps(("Status : FAIL", exc.returncode, exc.output), indent=2))
 else:
-    print("Output: \n{}\n".format(output))
+    print(json.dumps(("Output: \n{}\n".format(output)), indent=2))
 
 print(json.dumps(alfreditems, indent=2))
 sys.stdout.flush()

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -55,7 +55,10 @@ try:
 except subprocess.CalledProcessError as exc:
     print(json.dumps(("Status : FAIL", exc.returncode, exc.output), indent=2))
 else:
-    print(json.dumps(("Output: \n{}\n".format(output)), indent=2))
+  json_data = {
+      alfreditems,
+      output,
+  }
 
-print(json.dumps(alfreditems, indent=2))
-sys.stdout.flush()
+  print(json.dumps(json_data, indent=2))
+  sys.stdout.flush()

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -7,7 +7,19 @@ import subprocess
 import sys
 import urllib.parse
 import uuid
+import logging
 
+# create an instance of the logger
+logger = logging.getLogger()
+
+# logging set up 
+log_format = logging.Formatter('%(asctime)-15s %(levelname)-2s %(message)s')
+sh = logging.StreamHandler()
+sh.setFormatter(log_format)
+
+# add the handler
+logger.addHandler(sh)
+logger.setLevel(logging.INFO)
 
 if __name__ == '__main__':
   '''

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -55,5 +55,5 @@ try:
 except Exception as e:
   logger.error(e)
 
-  print(json.dumps(alfreditems, indent=2))
-  sys.stdout.flush()
+print(json.dumps(alfreditems, indent=2))
+sys.stdout.flush()

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -44,7 +44,7 @@ if __name__ == '__main__':
 try:
   # https://stackoverflow.com/a/50466440
   urllib.parse.quote_plus = urllib.parse.quote
-  output = subprocess.call([
+  subprocess.call([
     'open', '-g',
     'alfred-google-viewer://update?%s' % urllib.parse.urlencode({
       'rawQuery': rawQuery,

--- a/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
+++ b/google-viewer/AlfredGoogleViewer/scripts/alfred-google-viewer
@@ -56,8 +56,8 @@ except subprocess.CalledProcessError as exc:
     print(json.dumps(("Status : FAIL", exc.returncode, exc.output), indent=2))
 else:
   json_data = {
-      alfreditems,
-      output,
+      "alfred_items": alfreditems,
+      "output": output,
   }
 
   print(json.dumps(json_data, indent=2))


### PR DESCRIPTION
**The code was updated to target a `textarea` instead of an `input`.**

Turns out the Google search was powered by simulating a form submission. To simulate this submission, we were previously targeting an `input` element on the Google search page and entering our query. 

However, Google has since updated that element to a `textarea`. 

Most relevant change: https://github.com/erikopinaldo/alfred-google/compare/bug/cached-preview?expand=1#diff-d11ab0e233cb68e68dd6bb20d2c2bbe189b9acb137e5c73522354cb3db0dabeeR95

The other changes were related to logging. 